### PR TITLE
BaseAdress is no longer used

### DIFF
--- a/dvelop-sdk-identityprovider/IdentityProviderMiddleware.UnitTest/IdentityProviderMiddlewareTest.cs
+++ b/dvelop-sdk-identityprovider/IdentityProviderMiddleware.UnitTest/IdentityProviderMiddlewareTest.cs
@@ -153,7 +153,6 @@ namespace Dvelop.Sdk.IdentityProviderMiddleware.UnitTest
             await new IdentityProvider.Middleware.IdentityProviderMiddleware(nextMiddleware.InvokeAsync,
                     new IdentityProviderOptions
                     {
-                        BaseAddress = new Uri(DefaultSystemBaseUri),
                         TriggerAuthentication = false,
                         AllowExternalValidation = allowExternalValidation,
                         TenantInformationCallback = () => new TenantInformation{ TenantId = "0", SystemBaseUri = "https://localhost"},

--- a/dvelop-sdk-identityprovider/IdentityProviderMiddleware/IdentityProviderOptions.cs
+++ b/dvelop-sdk-identityprovider/IdentityProviderMiddleware/IdentityProviderOptions.cs
@@ -8,12 +8,9 @@ namespace Dvelop.Sdk.IdentityProvider.Middleware
     {
         public IdentityProviderOptions()
         {
-            BaseAddress = new Uri("http://localhost");
             TriggerAuthentication = false;
             AllowExternalValidation = false;
         }
-
-        public Uri BaseAddress { get; set; }
 
         public bool TriggerAuthentication { get; set; }
 


### PR DESCRIPTION
The systemBaseUri is only set via _tenantInformationCallback()