### PR TITLE
Separated logging of scope information and logging of custom attributes

### DIFF
--- a/dvelop-sdk-logging/Logging.Abstractions/Scope/CustomAttributesLogScope.cs
+++ b/dvelop-sdk-logging/Logging.Abstractions/Scope/CustomAttributesLogScope.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace Dvelop.Sdk.Logging.Abstractions.Scope
+{
+    public interface ICustomAttributesLogScope
+    {
+        Dictionary<string, object> Items { get; }
+        string Name { get; }
+    }
+
+    public class CustomAttributesLogScope : ICustomAttributesLogScope
+    {
+        public Dictionary<string, object> Items { get; }
+        public string Name { get; }
+
+        public CustomAttributesLogScope(string name, Dictionary<string, object> items)
+        {
+            Name = name;
+            Items = items;
+        }
+    }
+}

--- a/dvelop-sdk-logging/Logging.OtelJsonConsole/Scope/ScopeInfo.cs
+++ b/dvelop-sdk-logging/Logging.OtelJsonConsole/Scope/ScopeInfo.cs
@@ -6,7 +6,8 @@ namespace Dvelop.Sdk.Logging.OtelJsonConsole.Scope
     internal class ScopeInfo
     {
         public bool Visible { get; set; }
-        public IList<object> CustomAttributes { get; set; }
+        public IList<ICustomAttributesLogScope> CustomAttributes { get; set; }
+        public IList<object> Scopes { get; set; }
         public TenantLogScope TenantLogScope { get; set; }
         public TracingLogScope TracingLogScope { get; set; }
     }


### PR DESCRIPTION
With this change, it is possible to add a bunch of attributes to many log lines with a scope. It is no longer required to enable scope logging (IncludeScopes) which had some disadvantages. Since this feature didn't work in the past anyway, this change won't break any existing implementations.