### PR TITLE
Added some classes for better logging of incoming and outgoing requests

### DIFF
--- a/DvelopSdk.sln
+++ b/DvelopSdk.sln
@@ -83,6 +83,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dvelop-sdk-dash", "dvelop-s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DashboardDtos", "dvelop-sdk-dash\DashboardDtos\DashboardDtos.csproj", "{5EEA5C21-2CE7-42C3-8FB7-188571CAA8C6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BaseInterfaces", "dvelop-sdk-base\BaseInterfaces\BaseInterfaces.csproj", "{42CCC667-46E9-49C9-9C04-5FEE20A97831}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -169,6 +171,10 @@ Global
 		{5EEA5C21-2CE7-42C3-8FB7-188571CAA8C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5EEA5C21-2CE7-42C3-8FB7-188571CAA8C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5EEA5C21-2CE7-42C3-8FB7-188571CAA8C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42CCC667-46E9-49C9-9C04-5FEE20A97831}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42CCC667-46E9-49C9-9C04-5FEE20A97831}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42CCC667-46E9-49C9-9C04-5FEE20A97831}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42CCC667-46E9-49C9-9C04-5FEE20A97831}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -194,6 +200,7 @@ Global
 		{515ACCA1-CD62-4664-90F8-E79E82CD2E4F} = {2D132120-C170-4A76-9F1E-0933D731FF14}
 		{0D10264B-EE91-4CE0-B50F-B3115C5DEB79} = {2D132120-C170-4A76-9F1E-0933D731FF14}
 		{5EEA5C21-2CE7-42C3-8FB7-188571CAA8C6} = {B13E82B5-0C1F-48D6-83E5-5430F84154BA}
+		{42CCC667-46E9-49C9-9C04-5FEE20A97831} = {F992A8F0-E3DA-4ABF-9817-7663F66852EB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DE71353A-0FC5-4E2E-9DB1-4E09961F1201}

--- a/dvelop-sdk-base/BaseInterfaces/BaseInterfaces.csproj
+++ b/dvelop-sdk-base/BaseInterfaces/BaseInterfaces.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <RootNamespace>Dvelop.Sdk.BaseInterfaces</RootNamespace>
+    </PropertyGroup>
+
+</Project>

--- a/dvelop-sdk-base/BaseInterfaces/BaseInterfaces.csproj
+++ b/dvelop-sdk-base/BaseInterfaces/BaseInterfaces.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <RootNamespace>Dvelop.Sdk.BaseInterfaces</RootNamespace>
+        <AssemblyName>Dvelop.Sdk.BaseInterfaces</AssemblyName>
     </PropertyGroup>
 
 </Project>

--- a/dvelop-sdk-base/BaseInterfaces/IRequestContext.cs
+++ b/dvelop-sdk-base/BaseInterfaces/IRequestContext.cs
@@ -1,0 +1,8 @@
+namespace Dvelop.Sdk.BaseInterfaces
+{
+    public interface IRequestContext
+    {
+        string DvRequestId { get; }
+        string W3CTraceId { get; }
+    }
+}

--- a/dvelop-sdk-base/BaseInterfaces/ITenantContext.cs
+++ b/dvelop-sdk-base/BaseInterfaces/ITenantContext.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Dvelop.Sdk.BaseInterfaces
+{
+    public interface ITenantContext
+    {
+        string TenantId { get; }
+        Uri SystemBaseUri { get; } 
+    }
+}

--- a/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/EnsureSystemBaseUriHandler.cs
+++ b/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/EnsureSystemBaseUriHandler.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Dvelop.Sdk.BaseInterfaces;
+
+namespace Dvelop.Sdk.HttpClientExtensions.DelegatingHandler
+{
+    public class EnsureSystemBaseUriHandler: System.Net.Http.DelegatingHandler
+    {
+        private readonly ITenantContext _tenantContext;
+
+        public EnsureSystemBaseUriHandler(ITenantContext tenantContext)
+        {
+            _tenantContext = tenantContext;
+        }
+        
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.RequestUri = new Uri(_tenantContext.SystemBaseUri, request.RequestUri.PathAndQuery);
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/ForwardDvRequestIdHandler.cs
+++ b/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/ForwardDvRequestIdHandler.cs
@@ -1,0 +1,30 @@
+﻿using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Dvelop.Sdk.BaseInterfaces;
+
+namespace Dvelop.Sdk.HttpClientExtensions.DelegatingHandler
+{
+    public class ForwardDvRequestIdHandler: System.Net.Http.DelegatingHandler
+    {
+        private const string REQUEST_ID_HEADER = "x-dv-request-id";
+        
+        private readonly IRequestContext _requestContext;
+        
+        public ForwardDvRequestIdHandler(IRequestContext requestContext)
+        {
+            _requestContext = requestContext;
+        }
+        
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrEmpty(_requestContext.DvRequestId) && request?.Headers != null && request.Headers.Contains(REQUEST_ID_HEADER))
+            {
+                request?.Headers?.Add(REQUEST_ID_HEADER, _requestContext.DvRequestId);
+            }
+            
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/ForwardDvRequestIdHandler.cs
+++ b/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/ForwardDvRequestIdHandler.cs
@@ -19,11 +19,20 @@ namespace Dvelop.Sdk.HttpClientExtensions.DelegatingHandler
         
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (!string.IsNullOrEmpty(_requestContext.DvRequestId) && request?.Headers != null && request.Headers.Contains(REQUEST_ID_HEADER))
+            if (request?.Headers == null || !request.Headers.Contains(REQUEST_ID_HEADER))
             {
-                request?.Headers?.Add(REQUEST_ID_HEADER, _requestContext.DvRequestId);
+                return base.SendAsync(request, cancellationToken);
             }
             
+            if (!string.IsNullOrEmpty(_requestContext.DvRequestId))
+            {
+                request?.Headers?.Add(REQUEST_ID_HEADER, _requestContext.DvRequestId);
+            } 
+            else if(!string.IsNullOrEmpty(_requestContext.W3CTraceId))
+            {
+                request?.Headers?.Add(REQUEST_ID_HEADER, _requestContext.W3CTraceId);
+            }
+
             return base.SendAsync(request, cancellationToken);
         }
     }

--- a/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/ForwardW3CTraceHandler.cs
+++ b/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/ForwardW3CTraceHandler.cs
@@ -1,0 +1,28 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Dvelop.Sdk.BaseInterfaces;
+
+namespace Dvelop.Sdk.HttpClientExtensions.DelegatingHandler
+{
+    public class ForwardW3CTraceHandler : System.Net.Http.DelegatingHandler
+    {
+        private const string TRACEPARENT = "traceparent";
+        
+        private readonly IRequestContext _requestContext;
+
+        public ForwardW3CTraceHandler(IRequestContext requestContext)
+        {
+            _requestContext = requestContext;
+        }
+        
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrEmpty(_requestContext.W3CTraceId) && request?.Headers != null && !request.Headers.Contains(TRACEPARENT))
+            {
+                request.Headers.Add(TRACEPARENT, _requestContext.W3CTraceId);
+            }
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/OutgoingHttpRequestLoggingHandler.cs
+++ b/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/OutgoingHttpRequestLoggingHandler.cs
@@ -19,20 +19,20 @@ namespace Dvelop.Sdk.HttpClientExtensions.DelegatingHandler
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-                var x = new OutgoingHttpRequestLogScope
+                var requestLogScope = new OutgoingHttpRequestLogScope
                 {
                     Method = request.Method?.ToString(),
                     Target = request.RequestUri?.PathAndQuery,
                 };
            
-                _logger.LogWithState(LogLevel.Debug, $"Start HTTP {x.Method} call to {x.Target}",x);
+                _logger.LogWithState(LogLevel.Debug, $"Start HTTP {requestLogScope.Method} call to {requestLogScope.Target}",requestLogScope);
                 var sw = Stopwatch.StartNew();
                 var response = await base.SendAsync(request, cancellationToken);
                 var elapsed = sw.ElapsedMilliseconds;
                 
-                x.StatusCode = (int)response.StatusCode;
-                x.Elapsed = elapsed;
-                _logger.LogWithState(LogLevel.Debug ,$"Finished HTTP {x.Method} call to {x.Target} with status {(int)response.StatusCode} in ", x);
+                requestLogScope.StatusCode = (int)response.StatusCode;
+                requestLogScope.ClientDuration = elapsed;
+                _logger.LogWithState(LogLevel.Debug ,$"Finished HTTP {requestLogScope.Method} call to {requestLogScope.Target} with status {(int)response.StatusCode} in {requestLogScope.ClientDuration}", requestLogScope);
                 return response;    
             }
         }

--- a/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/OutgoingHttpRequestLoggingHandler.cs
+++ b/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/OutgoingHttpRequestLoggingHandler.cs
@@ -1,0 +1,39 @@
+﻿using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Dvelop.Sdk.Logging.Abstractions.Extension;
+using Dvelop.Sdk.Logging.Abstractions.Scope;
+using Microsoft.Extensions.Logging;
+
+namespace Dvelop.Sdk.HttpClientExtensions.DelegatingHandler
+{
+    public class OutgoingHttpRequestLoggingHandler : System.Net.Http.DelegatingHandler
+    {
+        private readonly ILogger<OutgoingHttpRequestLoggingHandler> _logger;
+
+        public OutgoingHttpRequestLoggingHandler(ILogger<OutgoingHttpRequestLoggingHandler> logger)
+        {
+            _logger = logger;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+                var x = new OutgoingHttpRequestLogScope
+                {
+                    Method = request.Method?.ToString(),
+                    Target = request.RequestUri?.PathAndQuery,
+                };
+           
+                _logger.LogWithState(LogLevel.Debug, $"Start HTTP {x.Method} call to {x.Target}",x);
+                var sw = Stopwatch.StartNew();
+                var response = await base.SendAsync(request, cancellationToken);
+                var elapsed = sw.ElapsedMilliseconds;
+                
+                x.StatusCode = (int)response.StatusCode;
+                x.Elapsed = elapsed;
+                _logger.LogWithState(LogLevel.Debug ,$"Finished HTTP {x.Method} call to {x.Target} with status {(int)response.StatusCode} in ", x);
+                return response;    
+            }
+        }
+}

--- a/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/OutgoingHttpRequestLoggingHandler.cs
+++ b/dvelop-sdk-httpclientextensions/HttpClientExtensions/DelegatingHandler/OutgoingHttpRequestLoggingHandler.cs
@@ -25,14 +25,14 @@ namespace Dvelop.Sdk.HttpClientExtensions.DelegatingHandler
                     Target = request.RequestUri?.PathAndQuery,
                 };
            
-                _logger.LogWithState(LogLevel.Debug, $"Start HTTP {requestLogScope.Method} call to {requestLogScope.Target}",requestLogScope);
+                _logger.LogWithState(LogLevel.Debug, $"Start outgoing {requestLogScope.Method} request to {requestLogScope.Target}",requestLogScope);
                 var sw = Stopwatch.StartNew();
                 var response = await base.SendAsync(request, cancellationToken);
                 var elapsed = sw.ElapsedMilliseconds;
                 
                 requestLogScope.StatusCode = (int)response.StatusCode;
                 requestLogScope.ClientDuration = elapsed;
-                _logger.LogWithState(LogLevel.Debug ,$"Finished HTTP {requestLogScope.Method} call to {requestLogScope.Target} with status {(int)response.StatusCode} in {requestLogScope.ClientDuration}", requestLogScope);
+                _logger.LogWithState(LogLevel.Debug ,$"Finished outgoing {requestLogScope.Method} request to {requestLogScope.Target} with status code {(int)response.StatusCode} in {requestLogScope.ClientDuration}ms", requestLogScope);
                 return response;    
             }
         }

--- a/dvelop-sdk-httpclientextensions/HttpClientExtensions/HttpClientExtensions.csproj
+++ b/dvelop-sdk-httpclientextensions/HttpClientExtensions/HttpClientExtensions.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\dvelop-sdk-base\BaseInterfaces\BaseInterfaces.csproj" />
       <ProjectReference Include="..\..\dvelop-sdk-signing\SigningAlgorithms\SigningAlgorithms.csproj" />
     </ItemGroup>
 

--- a/dvelop-sdk-httpclientextensions/HttpClientExtensions/HttpClientExtensions.csproj
+++ b/dvelop-sdk-httpclientextensions/HttpClientExtensions/HttpClientExtensions.csproj
@@ -18,6 +18,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\dvelop-sdk-base\BaseInterfaces\BaseInterfaces.csproj" />
+      <ProjectReference Include="..\..\dvelop-sdk-logging\Logging.Abstractions\Logging.Abstractions.csproj" />
       <ProjectReference Include="..\..\dvelop-sdk-signing\SigningAlgorithms\SigningAlgorithms.csproj" />
     </ItemGroup>
 

--- a/dvelop-sdk-logging/Logging.Abstractions/Logging.Abstractions.csproj
+++ b/dvelop-sdk-logging/Logging.Abstractions/Logging.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dvelop.Sdk.Logging.Abstractions</AssemblyName>
     <RootNamespace>Dvelop.Sdk.Logging.Abstractions</RootNamespace>
     <LangVersion>8</LangVersion>

--- a/dvelop-sdk-logging/Logging.Abstractions/Scope/IncomingHttpLogScope.cs
+++ b/dvelop-sdk-logging/Logging.Abstractions/Scope/IncomingHttpLogScope.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using Dvelop.Sdk.Logging.Abstractions.State;
+using Dvelop.Sdk.Logging.Abstractions.State.Attribute;
+
+namespace Dvelop.Sdk.Logging.Abstractions.Scope
+{
+    public class IncomingHttpRequestLogScope : CustomLogAttributeState
+    {
+        public string Method { get; set; }
+        public string Target { get; set; }
+        public string UserAgent { get; set; }
+        public int? Status { get; set; }
+        public long? Elapsed { get; set; }
+
+        public override IEnumerable<CustomLogAttribute> Attributes
+        {
+            get
+            {
+                var attributes = new List<CustomLogAttribute>();
+                var httpAttributes = new List<CustomLogAttribute>();
+                if (!string.IsNullOrEmpty(Method))
+                {
+                    httpAttributes.Add(new CustomLogAttributeProperty("method", Method));
+                }
+
+                if (!string.IsNullOrEmpty(Target))
+                {
+                    httpAttributes.Add(new CustomLogAttributeProperty("target", Target));
+                }
+                
+                if (!string.IsNullOrEmpty(UserAgent))
+                {
+                    httpAttributes.Add(new CustomLogAttributeProperty("userAgent", UserAgent));
+                }
+
+                if (Status != 0)
+                {
+                    httpAttributes.Add(new CustomLogAttributeProperty("status", Status));
+                }
+
+                if (Elapsed != 0)
+                {
+                    httpAttributes.Add(new CustomLogAttributeProperty("elapsed", Elapsed));
+                }
+
+                httpAttributes.Add(new CustomLogAttributeProperty("direction", "inbound"));
+                attributes.Add(new CustomLogAttributeObject("http", httpAttributes));
+                return attributes;
+            }
+        }
+    }
+}

--- a/dvelop-sdk-logging/Logging.Abstractions/Scope/IncomingHttpLogScope.cs
+++ b/dvelop-sdk-logging/Logging.Abstractions/Scope/IncomingHttpLogScope.cs
@@ -10,7 +10,7 @@ namespace Dvelop.Sdk.Logging.Abstractions.Scope
         public string Target { get; set; }
         public string UserAgent { get; set; }
         public int? Status { get; set; }
-        public long? Elapsed { get; set; }
+        public long? ServerDuration { get; set; }
 
         public override IEnumerable<CustomLogAttribute> Attributes
         {
@@ -38,9 +38,11 @@ namespace Dvelop.Sdk.Logging.Abstractions.Scope
                     httpAttributes.Add(new CustomLogAttributeProperty("status", Status));
                 }
 
-                if (Elapsed != 0)
+                if (ServerDuration != 0)
                 {
-                    httpAttributes.Add(new CustomLogAttributeProperty("elapsed", Elapsed));
+                    httpAttributes.Add(new CustomLogAttributeObject("server", new List<CustomLogAttribute>{
+                        new CustomLogAttributeProperty("duration", ServerDuration)
+                    }));
                 }
 
                 httpAttributes.Add(new CustomLogAttributeProperty("direction", "inbound"));

--- a/dvelop-sdk-logging/Logging.Abstractions/Scope/OutgoingHttpRequestLogScope.cs
+++ b/dvelop-sdk-logging/Logging.Abstractions/Scope/OutgoingHttpRequestLogScope.cs
@@ -44,5 +44,7 @@ namespace Dvelop.Sdk.Logging.Abstractions.Scope
                 return attributes;
             }
         }
+
+        
     }
 }

--- a/dvelop-sdk-logging/Logging.Abstractions/Scope/OutgoingHttpRequestLogScope.cs
+++ b/dvelop-sdk-logging/Logging.Abstractions/Scope/OutgoingHttpRequestLogScope.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using Dvelop.Sdk.Logging.Abstractions.State;
+using Dvelop.Sdk.Logging.Abstractions.State.Attribute;
+
+namespace Dvelop.Sdk.Logging.Abstractions.Scope
+{
+    public class OutgoingHttpRequestLogScope : CustomLogAttributeState
+    {
+        public string Method { get; set; }
+        public string Target { get; set; }
+        public int StatusCode { get; set; }
+        public long Elapsed { get; set; }
+
+        public override IEnumerable<CustomLogAttribute> Attributes
+        {
+            get
+            {
+                var attributes = new List<CustomLogAttribute>();
+                var httpAttributes = new List<CustomLogAttribute>();
+                if (!string.IsNullOrEmpty(Method))
+                {
+                    httpAttributes.Add(new CustomLogAttributeProperty("method", Method));
+                }
+
+                if (!string.IsNullOrEmpty(Target))
+                {
+                    httpAttributes.Add(new CustomLogAttributeProperty("target", Target));
+                }
+
+                if (StatusCode != 0)
+                {
+                    httpAttributes.Add(new CustomLogAttributeProperty("statusCode", StatusCode));
+                }
+
+                if (Elapsed != 0)
+                {
+                    httpAttributes.Add(new CustomLogAttributeProperty("elapsed", Elapsed));
+                }
+
+                httpAttributes.Add(new CustomLogAttributeProperty("direction", "outbound"));
+                attributes.Add(new CustomLogAttributeObject("http", httpAttributes));
+                return attributes;
+            }
+        }
+    }
+}

--- a/dvelop-sdk-logging/Logging.Abstractions/Scope/OutgoingHttpRequestLogScope.cs
+++ b/dvelop-sdk-logging/Logging.Abstractions/Scope/OutgoingHttpRequestLogScope.cs
@@ -9,7 +9,7 @@ namespace Dvelop.Sdk.Logging.Abstractions.Scope
         public string Method { get; set; }
         public string Target { get; set; }
         public int StatusCode { get; set; }
-        public long Elapsed { get; set; }
+        public long ClientDuration { get; set; }
 
         public override IEnumerable<CustomLogAttribute> Attributes
         {
@@ -32,9 +32,11 @@ namespace Dvelop.Sdk.Logging.Abstractions.Scope
                     httpAttributes.Add(new CustomLogAttributeProperty("statusCode", StatusCode));
                 }
 
-                if (Elapsed != 0)
+                if (ClientDuration != 0)
                 {
-                    httpAttributes.Add(new CustomLogAttributeProperty("elapsed", Elapsed));
+                    httpAttributes.Add(new CustomLogAttributeObject("client", new List<CustomLogAttribute>{
+                        new CustomLogAttributeProperty("duration", ClientDuration)
+                    }));
                 }
 
                 httpAttributes.Add(new CustomLogAttributeProperty("direction", "outbound"));

--- a/dvelop-sdk-webapi/WebApiExtensions/Context/RequestContext.cs
+++ b/dvelop-sdk-webapi/WebApiExtensions/Context/RequestContext.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics;
+using Dvelop.Sdk.BaseInterfaces;
+using Microsoft.AspNetCore.Http;
+
+namespace Dvelop.Sdk.WebApiExtensions.Context
+{
+    public class RequestContext: IRequestContext
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public RequestContext(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+        
+        public string DvRequestId => _httpContextAccessor.HttpContext.Request.Headers["x-dv-request-id"];
+
+        public string W3CTraceId => Activity.Current?.Id ?? _httpContextAccessor.HttpContext.TraceIdentifier;
+    }
+}

--- a/dvelop-sdk-webapi/WebApiExtensions/Context/RequestContext.cs
+++ b/dvelop-sdk-webapi/WebApiExtensions/Context/RequestContext.cs
@@ -6,6 +6,7 @@ namespace Dvelop.Sdk.WebApiExtensions.Context
 {
     public class RequestContext: IRequestContext
     {
+        private const string REQUEST_ID_HEADER = "x-dv-request-id";
         private readonly IHttpContextAccessor _httpContextAccessor;
 
         public RequestContext(IHttpContextAccessor httpContextAccessor)
@@ -13,7 +14,7 @@ namespace Dvelop.Sdk.WebApiExtensions.Context
             _httpContextAccessor = httpContextAccessor;
         }
         
-        public string DvRequestId => _httpContextAccessor.HttpContext.Request.Headers["x-dv-request-id"];
+        public string DvRequestId => _httpContextAccessor.HttpContext.Request.Headers[REQUEST_ID_HEADER];
 
         public string W3CTraceId => Activity.Current?.Id ?? _httpContextAccessor.HttpContext.TraceIdentifier;
     }

--- a/dvelop-sdk-webapi/WebApiExtensions/Context/TenantContext.cs
+++ b/dvelop-sdk-webapi/WebApiExtensions/Context/TenantContext.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Dvelop.Sdk.BaseInterfaces;
+using Microsoft.AspNetCore.Http;
+
+namespace Dvelop.Sdk.WebApiExtensions.Context
+{
+    public class TenantContext : ITenantContext
+    {
+        private readonly IHttpContextAccessor _context;
+
+        private static readonly string TenantIdKey = $"{nameof(ITenantContext)}.{nameof(TenantId)}";
+        private static readonly string SystemBaseUriKey = $"{nameof(ITenantContext)}.{nameof(SystemBaseUri)}";
+
+        public TenantContext(IHttpContextAccessor context)
+        {
+            _context = context;
+        }
+
+        public string TenantId
+        {
+            get => _context.HttpContext.Items[TenantIdKey] as string;
+            set => _context.HttpContext.Items[TenantIdKey] = value;
+        }
+        
+        public Uri SystemBaseUri
+        {
+            get => _context.HttpContext.Items[SystemBaseUriKey] as Uri;
+            set => _context.HttpContext.Items[SystemBaseUriKey] = value;
+        }
+    }
+}

--- a/dvelop-sdk-webapi/WebApiExtensions/Middleware/RequestLoggingMiddleware.cs
+++ b/dvelop-sdk-webapi/WebApiExtensions/Middleware/RequestLoggingMiddleware.cs
@@ -1,0 +1,48 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using Dvelop.Sdk.BaseInterfaces;
+using Dvelop.Sdk.Logging.Abstractions.Extension;
+using Dvelop.Sdk.Logging.Abstractions.Scope;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
+
+namespace Dvelop.Sdk.WebApiExtensions.Middleware
+{
+    public class RequestLoggingMiddleware
+    {
+        private readonly ILogger<RequestLoggingMiddleware> _logger;
+ 
+        private readonly RequestDelegate _next;
+        private readonly ITenantContext _tenantRepository;
+
+        public RequestLoggingMiddleware(RequestDelegate next, ITenantContext tenantRepository, ILogger<RequestLoggingMiddleware> logger)
+        {
+            _logger = logger;
+            _next = next;
+            _tenantRepository = tenantRepository;
+        }
+ 
+        public async Task InvokeAsync(HttpContext context)
+        {
+            using (_logger.BeginScope(new TracingLogScope(Activity.Current?.TraceId.ToString(), Activity.Current?.SpanId.ToString())))
+            using (_logger.BeginScope(new TenantLogScope(_tenantRepository?.TenantId)))
+            {
+                var httpRequest = context.Request;
+                var logScope = new IncomingHttpRequestLogScope
+                {
+                    Method = httpRequest?.Method,
+                    Target = httpRequest?.Path,
+                    UserAgent = httpRequest?.Headers[HeaderNames.UserAgent]
+                };
+                var sw = Stopwatch.StartNew();
+                _logger.LogWithState( LogLevel.Debug, $"Start {logScope.Method} to {logScope.Target}", logScope );
+                var elapsed = sw.ElapsedMilliseconds;
+                logScope.Elapsed = elapsed;
+                logScope.Status = context.Response?.StatusCode;
+                await _next(context);
+                _logger.LogWithState( LogLevel.Debug, $"Finished {logScope.Method} to {logScope.Target} with {logScope.Status} in {logScope.Elapsed}", logScope );
+            }
+        }
+    }
+}

--- a/dvelop-sdk-webapi/WebApiExtensions/Middleware/RequestLoggingMiddleware.cs
+++ b/dvelop-sdk-webapi/WebApiExtensions/Middleware/RequestLoggingMiddleware.cs
@@ -36,12 +36,12 @@ namespace Dvelop.Sdk.WebApiExtensions.Middleware
                     UserAgent = httpRequest?.Headers[HeaderNames.UserAgent]
                 };
                 var sw = Stopwatch.StartNew();
-                _logger.LogWithState( LogLevel.Debug, $"Start {logScope.Method} to {logScope.Target}", logScope );
-                var elapsed = sw.ElapsedMilliseconds;
-                logScope.Elapsed = elapsed;
-                logScope.Status = context.Response?.StatusCode;
+                _logger.LogWithState( LogLevel.Debug, $"Start incoming {logScope.Method} to {logScope.Target}", logScope );
                 await _next(context);
-                _logger.LogWithState( LogLevel.Debug, $"Finished {logScope.Method} to {logScope.Target} with {logScope.Status} in {logScope.Elapsed}", logScope );
+                var elapsed = sw.ElapsedMilliseconds;
+                logScope.ServerDuration = elapsed;
+                logScope.Status = context.Response?.StatusCode;
+                _logger.LogWithState( LogLevel.Debug, $"Finished incoming {logScope.Method} to {logScope.Target} with {logScope.Status} in {logScope.ServerDuration}", logScope );
             }
         }
     }

--- a/dvelop-sdk-webapi/WebApiExtensions/Middleware/RequestLoggingMiddleware.cs
+++ b/dvelop-sdk-webapi/WebApiExtensions/Middleware/RequestLoggingMiddleware.cs
@@ -4,6 +4,7 @@ using Dvelop.Sdk.BaseInterfaces;
 using Dvelop.Sdk.Logging.Abstractions.Extension;
 using Dvelop.Sdk.Logging.Abstractions.Scope;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 
@@ -37,11 +38,12 @@ namespace Dvelop.Sdk.WebApiExtensions.Middleware
                 };
                 var sw = Stopwatch.StartNew();
                 _logger.LogWithState( LogLevel.Debug, $"Start incoming {logScope.Method} to {logScope.Target}", logScope );
+                
                 await _next(context);
                 var elapsed = sw.ElapsedMilliseconds;
                 logScope.ServerDuration = elapsed;
                 logScope.Status = context.Response?.StatusCode;
-                _logger.LogWithState( LogLevel.Debug, $"Finished incoming {logScope.Method} to {logScope.Target} with {logScope.Status} in {logScope.ServerDuration}", logScope );
+                _logger.LogWithState( LogLevel.Debug, $"Finished incoming {logScope.Method} to {logScope.Target} with status code {logScope.Status} in {logScope.ServerDuration}ms", logScope );
             }
         }
     }

--- a/dvelop-sdk-webapi/WebApiExtensions/Middleware/W3CTracingMiddleware.cs
+++ b/dvelop-sdk-webapi/WebApiExtensions/Middleware/W3CTracingMiddleware.cs
@@ -1,0 +1,34 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Dvelop.Sdk.WebApiExtensions.Middleware
+{
+    public class W3CTracingMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public W3CTracingMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            if (Activity.Current == null)
+            {
+                var activity = new Activity("");
+
+                if (context.Request.Headers.TryGetValue("traceparent", out var traceparent) && traceparent.Count >= 1)
+                {
+                    activity.SetParentId(traceparent[0]);
+                }
+
+                activity.Start();
+                Activity.Current = activity;
+            }
+
+            await _next(context).ConfigureAwait(false);
+        }
+    }
+}

--- a/dvelop-sdk-webapi/WebApiExtensions/WebApiExtensions.csproj
+++ b/dvelop-sdk-webapi/WebApiExtensions/WebApiExtensions.csproj
@@ -22,6 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\dvelop-sdk-base\BaseInterfaces\BaseInterfaces.csproj" />
       <ProjectReference Include="..\..\dvelop-sdk-signing\SigningAlgorithms\SigningAlgorithms.csproj" />
     </ItemGroup>
 

--- a/dvelop-sdk-webapi/WebApiExtensions/WebApiExtensions.csproj
+++ b/dvelop-sdk-webapi/WebApiExtensions/WebApiExtensions.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
   </ItemGroup>
 
 

--- a/dvelop-sdk-webapi/WebApiExtensions/WebApiExtensions.csproj
+++ b/dvelop-sdk-webapi/WebApiExtensions/WebApiExtensions.csproj
@@ -23,6 +23,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\dvelop-sdk-base\BaseInterfaces\BaseInterfaces.csproj" />
+      <ProjectReference Include="..\..\dvelop-sdk-logging\Logging.Abstractions\Logging.Abstractions.csproj" />
       <ProjectReference Include="..\..\dvelop-sdk-signing\SigningAlgorithms\SigningAlgorithms.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
Added some classes for better logging of incoming and outgoing requests.

For WebApi server
- A middleware to enable logging all incoming requests (before, after)
- A class to collect x-dv-request-id, oder W3cTraceIds
- A class to collect tenant-id and systemBaseUri

For HttpClient
- DelegatingHandler to set SystemBaseUri
- DelegatingHandler to forward the (deprecated) x-dv-request-id handler
- DelegatingHandler to forward W3C tracer header
- DelegatingHandler to log all outgoing requests

Base Interface for some request based information