### PR TITLE
update dependencies & remove old ASP.NET Core v2.2 dependencies

### DIFF
--- a/dvelop-sdk-cloudcenter/CloudCenterDtos/CloudCenterDtos.csproj
+++ b/dvelop-sdk-cloudcenter/CloudCenterDtos/CloudCenterDtos.csproj
@@ -1,19 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>Dvelop.Sdk.CloudCenter.Dto</RootNamespace>
         <AssemblyName>Dvelop.Sdk.CloudCenter.Dto</AssemblyName>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <LangVersion>latestmajor</LangVersion>
+    </PropertyGroup>
     
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <LangVersion>latestmajor</LangVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    </ItemGroup>
 
 </Project>

--- a/dvelop-sdk-config/ConfigDtos/ConfigDtos.csproj
+++ b/dvelop-sdk-config/ConfigDtos/ConfigDtos.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/dvelop-sdk-httpclientextensions/HttpClientExtensions.UnitTest/HttpClientExtensions.UnitTest.csproj
+++ b/dvelop-sdk-httpclientextensions/HttpClientExtensions.UnitTest/HttpClientExtensions.UnitTest.csproj
@@ -10,8 +10,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
         <PackageReference Include="coverlet.collector" Version="6.0.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dvelop-sdk-identityprovider/IdentityProviderClient/IdentityProviderClient.csproj
+++ b/dvelop-sdk-identityprovider/IdentityProviderClient/IdentityProviderClient.csproj
@@ -17,7 +17,6 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/dvelop-sdk-identityprovider/IdentityProviderClient/IdentityProviderSessionStore.cs
+++ b/dvelop-sdk-identityprovider/IdentityProviderClient/IdentityProviderSessionStore.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
-
 using System.Security.Claims;
-using Microsoft.AspNetCore.Authentication;
 
 namespace Dvelop.Sdk.IdentityProvider.Client
 {

--- a/dvelop-sdk-identityprovider/IdentityProviderDtos/IdentityProviderDtos.csproj
+++ b/dvelop-sdk-identityprovider/IdentityProviderDtos/IdentityProviderDtos.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Dvelop.Sdk.IdentityProvider.Dto</AssemblyName>
-    <RootNamespace>Dvelop.Sdk.IdentityProvider.Dto</RootNamespace>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <AssemblyName>Dvelop.Sdk.IdentityProvider.Dto</AssemblyName>
+        <RootNamespace>Dvelop.Sdk.IdentityProvider.Dto</RootNamespace>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <LangVersion>latestmajor</LangVersion>
+    </PropertyGroup>
+  
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    </ItemGroup>
+  
 </Project>

--- a/dvelop-sdk-identityprovider/IdentityProviderMiddleware.UnitTest/IdentityProviderMiddleware.UnitTest.csproj
+++ b/dvelop-sdk-identityprovider/IdentityProviderMiddleware.UnitTest/IdentityProviderMiddleware.UnitTest.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dvelop-sdk-identityprovider/IdentityProviderMiddleware/IdentityProviderMiddleware.csproj
+++ b/dvelop-sdk-identityprovider/IdentityProviderMiddleware/IdentityProviderMiddleware.csproj
@@ -14,7 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/dvelop-sdk-identityprovider/IdentityProviderMiddleware/IdentityProviderMiddleware.csproj
+++ b/dvelop-sdk-identityprovider/IdentityProviderMiddleware/IdentityProviderMiddleware.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/dvelop-sdk-logging/Logging.Abstractions/Logging.Abstractions.csproj
+++ b/dvelop-sdk-logging/Logging.Abstractions/Logging.Abstractions.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
   </ItemGroup>
 
 </Project>

--- a/dvelop-sdk-logging/Logging.OtelJsonConsole/Logging.OtelJsonConsole.csproj
+++ b/dvelop-sdk-logging/Logging.OtelJsonConsole/Logging.OtelJsonConsole.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>
 

--- a/dvelop-sdk-signing/SigningAlgorithms.UnitTest/SigningAlgorithms.UnitTest.csproj
+++ b/dvelop-sdk-signing/SigningAlgorithms.UnitTest/SigningAlgorithms.UnitTest.csproj
@@ -10,7 +10,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
         <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />

--- a/dvelop-sdk-signing/SigningAlgorithms.UnitTest/SigningAlgorithms.UnitTest.csproj
+++ b/dvelop-sdk-signing/SigningAlgorithms.UnitTest/SigningAlgorithms.UnitTest.csproj
@@ -11,8 +11,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
         <PackageReference Include="coverlet.collector" Version="6.0.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dvelop-sdk-signing/SigningAlgorithms/SigningAlgorithms.csproj
+++ b/dvelop-sdk-signing/SigningAlgorithms/SigningAlgorithms.csproj
@@ -14,7 +14,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     </ItemGroup>
 
 </Project>

--- a/dvelop-sdk-signing/SigningAlgorithms/SigningAlgorithms.csproj
+++ b/dvelop-sdk-signing/SigningAlgorithms/SigningAlgorithms.csproj
@@ -7,20 +7,14 @@
         <RootNamespace>Dvelop.Sdk.SigningAlgorithms</RootNamespace>
         <LangVersion>latestmajor</LangVersion>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     </ItemGroup>
 
 </Project>

--- a/dvelop-sdk-tenant/TenantMiddleware.UnitTest/TenantMiddleware.UnitTest.csproj
+++ b/dvelop-sdk-tenant/TenantMiddleware.UnitTest/TenantMiddleware.UnitTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/dvelop-sdk-tenant/TenantMiddleware.UnitTest/TenantMiddleware.UnitTest.csproj
+++ b/dvelop-sdk-tenant/TenantMiddleware.UnitTest/TenantMiddleware.UnitTest.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dvelop-sdk-tenant/TenantMiddleware.UnitTest/TenantMiddleware.UnitTest.csproj
+++ b/dvelop-sdk-tenant/TenantMiddleware.UnitTest/TenantMiddleware.UnitTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />

--- a/dvelop-sdk-tenant/TenantMiddleware/TenantMiddleware.csproj
+++ b/dvelop-sdk-tenant/TenantMiddleware/TenantMiddleware.csproj
@@ -16,15 +16,12 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/dvelop-sdk-webapi/WebApiExtensions.UnitTest/Extensions/Dv1HmacSha256RequestSigningExtensionTest.cs
+++ b/dvelop-sdk-webapi/WebApiExtensions.UnitTest/Extensions/Dv1HmacSha256RequestSigningExtensionTest.cs
@@ -24,16 +24,12 @@ namespace Dvelop.Sdk.WebApiExtensions.UnitTest.Extensions
                     Path = "/myapp/dvelop-cloud-lifecycle-event",
                     ContentType = "application/json",
                     Body = new MemoryStream(Encoding.UTF8.GetBytes("{\"type\":\"subscribe\",\"tenantId\":\"id\",\"baseUri\":\"https://someone.d-velop.cloud\"}\n")),
-                    Headers =
-                    {
-                        {"x-dv-signature-timestamp","2019-08-09T08:49:42Z"},
-                        {"x-dv-signature-algorithm", "DV1-HMAC-SHA256"},
-                        {"x-dv-signature-headers", "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp"},
-                        {"Authorization","Bearer 02783453441665bf27aa465cbbac9b98507ae94c54b6be2b1882fe9a05ec104c"}
-                    }
                 }
             };
-            
+            x.Request.Headers.Authorization = "Bearer 02783453441665bf27aa465cbbac9b98507ae94c54b6be2b1882fe9a05ec104c";
+            x.Request.Headers["x-dv-signature-headers"] = "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp";
+            x.Request.Headers["x-dv-signature-algorithm"] = "DV1-HMAC-SHA256";
+            x.Request.Headers["x-dv-signature-timestamp"] = "2019-08-09T08:49:42Z";
             var features = x.HttpContext.Features.Get<IHttpRequestFeature>();
             features.RawTarget = "https://acme-apptemplate.service.d-velop.cloud/myapp/dvelop-cloud-lifecycle-event";
             var calculated = await x.Request.CalculateDv1HmacSha256Signature("Rg9iJXX0Jkun9u4Rp6no8HTNEdHlfX9aZYbFJ9b6YdQ=").ConfigureAwait(false);
@@ -51,15 +47,12 @@ namespace Dvelop.Sdk.WebApiExtensions.UnitTest.Extensions
                     Path = "/prod/acme-apptemplatecs/dvelop-cloud-lifecycle-event",
                     ContentType = "application/json",
                     Body = new MemoryStream(Encoding.UTF8.GetBytes("{\"type\":\"resubscribe\",\"tenantId\":\"id\",\"baseUri\":\"https://someone.d-velop.cloud\"}")),
-                    Headers =
-                    {
-                        { "x-dv-signature-timestamp", "2020-04-30T08:16:40Z" },
-                        { "x-dv-signature-algorithm", "DV1-HMAC-SHA256" },
-                        { "x-dv-signature-headers", "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp" },
-                        { "Authorization", "Bearer cc2bfbac52f30ddee41e4475963f8136c60cab678941560538b1281ad2722aac" }
-                    }
                 }
             };
+            x.Request.Headers.Authorization = "Bearer cc2bfbac52f30ddee41e4475963f8136c60cab678941560538b1281ad2722aac";
+            x.Request.Headers["x-dv-signature-headers"] = "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp";
+            x.Request.Headers["x-dv-signature-algorithm"] = "DV1-HMAC-SHA256";
+            x.Request.Headers["x-dv-signature-timestamp"] = "2020-04-30T08:16:40Z";
             var features = x.HttpContext.Features.Get<IHttpRequestFeature>();
             features.RawTarget = "https://acme-apptemplate.service.d-velop.cloud/prod/acme-apptemplatecs/dvelop-cloud-lifecycle-event";
             var calculated = await x.Request.CalculateDv1HmacSha256Signature("Rg9iJXX0Jkun9u4Rp6no8HTNEdHlfX9aZYbFJ9b6YdQ=").ConfigureAwait(false);
@@ -76,16 +69,13 @@ namespace Dvelop.Sdk.WebApiExtensions.UnitTest.Extensions
                     Method = "POST",
                     Path = "/prod/acme-apptemplatecs/dvelop-cloud-lifecycle-event",
                     ContentType = "application/json",
-                    Body = new MemoryStream(Encoding.UTF8.GetBytes("{\"type\":\"subscribe\",\"tenantId\":\"id\",\"baseUri\":\"https://someone.d-velop.cloud\"}\n")),
-                    Headers =
-                    {
-                        {"x-dv-SIGNATURE-timestamp","2019-08-09T08:49:42Z"},
-                        {"x-dv-signature-algorithm", "DV1-HMAC-SHA256"},
-                        {"x-dv-signature-headers", "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp"},
-                        {"Authorization","Bearer 58b07086ef6d987016d35c8ca2b0c1e48ed1aa8ffe31819402ad8f06c7bd4486"}
-                    }
+                    Body = new MemoryStream(Encoding.UTF8.GetBytes("{\"type\":\"subscribe\",\"tenantId\":\"id\",\"baseUri\":\"https://someone.d-velop.cloud\"}\n"))
                 }
             };
+            x.Request.Headers.Authorization = "Bearer 58b07086ef6d987016d35c8ca2b0c1e48ed1aa8ffe31819402ad8f06c7bd4486";
+            x.Request.Headers["x-dv-signature-headers"] = "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp";
+            x.Request.Headers["x-dv-signature-algorithm"] = "DV1-HMAC-SHA256";
+            x.Request.Headers["x-dv-SIGNATURE-timestamp"] = "2019-08-09T08:49:42Z";
             var features = x.HttpContext.Features.Get<IHttpRequestFeature>();
             features.RawTarget = "https://acme-apptemplate.service.d-velop.cloud/prod/acme-apptemplatecs/dvelop-cloud-lifecycle-event";
             var calculated = await x.Request.CalculateDv1HmacSha256Signature("Rg9iJXX0Jkun9u4Rp6no8HTNEdHlfX9aZYbFJ9b6YdQ=").ConfigureAwait(false);

--- a/dvelop-sdk-webapi/WebApiExtensions.UnitTest/Extensions/Dv1HmacSha256RequestSigningExtensionTest.cs
+++ b/dvelop-sdk-webapi/WebApiExtensions.UnitTest/Extensions/Dv1HmacSha256RequestSigningExtensionTest.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Dvelop.Sdk.WebApiExtensions.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Dvelop.Sdk.WebApiExtensions.UnitTest.Extensions
@@ -17,76 +16,80 @@ namespace Dvelop.Sdk.WebApiExtensions.UnitTest.Extensions
         [TestMethod]
         public async Task TestCalculateDv1HmacSha256SignatureFromExample()
         {
-            var x = new DefaultHttpRequest(new DefaultHttpContext())
+            var x = new DefaultHttpContext
             {
-                Method = "POST",
-                Path = "/myapp/dvelop-cloud-lifecycle-event",
-                ContentType = "application/json",
-                Body = new MemoryStream(Encoding.UTF8.GetBytes("{\"type\":\"subscribe\",\"tenantId\":\"id\",\"baseUri\":\"https://someone.d-velop.cloud\"}\n")),
-                Headers =
+                Request =
                 {
-                    {"x-dv-signature-timestamp","2019-08-09T08:49:42Z"},
-                    {"x-dv-signature-algorithm", "DV1-HMAC-SHA256"},
-                    {"x-dv-signature-headers", "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp"},
-                    {"Authorization","Bearer 02783453441665bf27aa465cbbac9b98507ae94c54b6be2b1882fe9a05ec104c"}
+                    Method = "POST",
+                    Path = "/myapp/dvelop-cloud-lifecycle-event",
+                    ContentType = "application/json",
+                    Body = new MemoryStream(Encoding.UTF8.GetBytes("{\"type\":\"subscribe\",\"tenantId\":\"id\",\"baseUri\":\"https://someone.d-velop.cloud\"}\n")),
+                    Headers =
+                    {
+                        {"x-dv-signature-timestamp","2019-08-09T08:49:42Z"},
+                        {"x-dv-signature-algorithm", "DV1-HMAC-SHA256"},
+                        {"x-dv-signature-headers", "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp"},
+                        {"Authorization","Bearer 02783453441665bf27aa465cbbac9b98507ae94c54b6be2b1882fe9a05ec104c"}
+                    }
                 }
             };
+            
             var features = x.HttpContext.Features.Get<IHttpRequestFeature>();
             features.RawTarget = "https://acme-apptemplate.service.d-velop.cloud/myapp/dvelop-cloud-lifecycle-event";
-            var calculated = await x.CalculateDv1HmacSha256Signature("Rg9iJXX0Jkun9u4Rp6no8HTNEdHlfX9aZYbFJ9b6YdQ=").ConfigureAwait(false);
+            var calculated = await x.Request.CalculateDv1HmacSha256Signature("Rg9iJXX0Jkun9u4Rp6no8HTNEdHlfX9aZYbFJ9b6YdQ=").ConfigureAwait(false);
             Assert.AreEqual( "02783453441665bf27aa465cbbac9b98507ae94c54b6be2b1882fe9a05ec104c", calculated );
         }
 
-        
-        
         [TestMethod]
         public async Task TestCalculateDv1HmacSha256Signature1()
         {
-            var x = new DefaultHttpRequest(new DefaultHttpContext())
+            var x = new DefaultHttpContext
             {
-                Method = "POST",
-                Path = "/prod/acme-apptemplatecs/dvelop-cloud-lifecycle-event",
-                ContentType = "application/json",
-                Body = new MemoryStream(Encoding.UTF8.GetBytes("{\"type\":\"resubscribe\",\"tenantId\":\"id\",\"baseUri\":\"https://someone.d-velop.cloud\"}")),
-                Headers =
+                Request =
                 {
-                    {"x-dv-signature-timestamp","2020-04-30T08:16:40Z"},
-                    {"x-dv-signature-algorithm", "DV1-HMAC-SHA256"},
-                    {"x-dv-signature-headers", "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp"},
-                    {"Authorization","Bearer cc2bfbac52f30ddee41e4475963f8136c60cab678941560538b1281ad2722aac"}
+                    Method = "POST",
+                    Path = "/prod/acme-apptemplatecs/dvelop-cloud-lifecycle-event",
+                    ContentType = "application/json",
+                    Body = new MemoryStream(Encoding.UTF8.GetBytes("{\"type\":\"resubscribe\",\"tenantId\":\"id\",\"baseUri\":\"https://someone.d-velop.cloud\"}")),
+                    Headers =
+                    {
+                        { "x-dv-signature-timestamp", "2020-04-30T08:16:40Z" },
+                        { "x-dv-signature-algorithm", "DV1-HMAC-SHA256" },
+                        { "x-dv-signature-headers", "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp" },
+                        { "Authorization", "Bearer cc2bfbac52f30ddee41e4475963f8136c60cab678941560538b1281ad2722aac" }
+                    }
                 }
             };
             var features = x.HttpContext.Features.Get<IHttpRequestFeature>();
             features.RawTarget = "https://acme-apptemplate.service.d-velop.cloud/prod/acme-apptemplatecs/dvelop-cloud-lifecycle-event";
-            var calculated = await x.CalculateDv1HmacSha256Signature("Rg9iJXX0Jkun9u4Rp6no8HTNEdHlfX9aZYbFJ9b6YdQ=").ConfigureAwait(false);
+            var calculated = await x.Request.CalculateDv1HmacSha256Signature("Rg9iJXX0Jkun9u4Rp6no8HTNEdHlfX9aZYbFJ9b6YdQ=").ConfigureAwait(false);
             Assert.AreEqual( "cc2bfbac52f30ddee41e4475963f8136c60cab678941560538b1281ad2722aac", calculated);
         }
-        
         
         [TestMethod]
         public async Task TestCalculateDv1HmacSha256Signature2()
         {
-            var x = new DefaultHttpRequest(new DefaultHttpContext())
+            var x = new DefaultHttpContext
             {
-                Method = "POST",
-                Path = "/prod/acme-apptemplatecs/dvelop-cloud-lifecycle-event",
-                ContentType = "application/json",
-                Body = new MemoryStream(Encoding.UTF8.GetBytes("{\"type\":\"subscribe\",\"tenantId\":\"id\",\"baseUri\":\"https://someone.d-velop.cloud\"}\n")),
-                Headers =
+                Request =
                 {
-                    {"x-dv-SIGNATURE-timestamp","2019-08-09T08:49:42Z"},
-                    {"x-dv-signature-algorithm", "DV1-HMAC-SHA256"},
-                    {"x-dv-signature-headers", "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp"},
-                    {"Authorization","Bearer 58b07086ef6d987016d35c8ca2b0c1e48ed1aa8ffe31819402ad8f06c7bd4486"}
+                    Method = "POST",
+                    Path = "/prod/acme-apptemplatecs/dvelop-cloud-lifecycle-event",
+                    ContentType = "application/json",
+                    Body = new MemoryStream(Encoding.UTF8.GetBytes("{\"type\":\"subscribe\",\"tenantId\":\"id\",\"baseUri\":\"https://someone.d-velop.cloud\"}\n")),
+                    Headers =
+                    {
+                        {"x-dv-SIGNATURE-timestamp","2019-08-09T08:49:42Z"},
+                        {"x-dv-signature-algorithm", "DV1-HMAC-SHA256"},
+                        {"x-dv-signature-headers", "x-dv-signature-algorithm,x-dv-signature-headers,x-dv-signature-timestamp"},
+                        {"Authorization","Bearer 58b07086ef6d987016d35c8ca2b0c1e48ed1aa8ffe31819402ad8f06c7bd4486"}
+                    }
                 }
             };
             var features = x.HttpContext.Features.Get<IHttpRequestFeature>();
             features.RawTarget = "https://acme-apptemplate.service.d-velop.cloud/prod/acme-apptemplatecs/dvelop-cloud-lifecycle-event";
-            var calculated = await x.CalculateDv1HmacSha256Signature("Rg9iJXX0Jkun9u4Rp6no8HTNEdHlfX9aZYbFJ9b6YdQ=").ConfigureAwait(false);
+            var calculated = await x.Request.CalculateDv1HmacSha256Signature("Rg9iJXX0Jkun9u4Rp6no8HTNEdHlfX9aZYbFJ9b6YdQ=").ConfigureAwait(false);
             Assert.AreEqual( "58b07086ef6d987016d35c8ca2b0c1e48ed1aa8ffe31819402ad8f06c7bd4486", calculated);
         }
-        
     }
-    
-    
 }

--- a/dvelop-sdk-webapi/WebApiExtensions.UnitTest/WebApiExtensions.UnitTest.csproj
+++ b/dvelop-sdk-webapi/WebApiExtensions.UnitTest/WebApiExtensions.UnitTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -15,7 +15,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
         <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />

--- a/dvelop-sdk-webapi/WebApiExtensions.UnitTest/WebApiExtensions.UnitTest.csproj
+++ b/dvelop-sdk-webapi/WebApiExtensions.UnitTest/WebApiExtensions.UnitTest.csproj
@@ -1,16 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-
         <IsPackable>false</IsPackable>
-
         <AssemblyName>Dvelop.Sdk.WebApiExtensions.UnitTest</AssemblyName>
-
         <RootNamespace>Dvelop.Sdk.WebApiExtensions.UnitTest</RootNamespace>
-
         <OutputType>Library</OutputType>
-
         <LangVersion>latestmajor</LangVersion>
     </PropertyGroup>
 

--- a/dvelop-sdk-webapi/WebApiExtensions.UnitTest/WebApiExtensions.UnitTest.csproj
+++ b/dvelop-sdk-webapi/WebApiExtensions.UnitTest/WebApiExtensions.UnitTest.csproj
@@ -11,8 +11,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
         <PackageReference Include="coverlet.collector" Version="6.0.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dvelop-sdk-webapi/WebApiExtensions/WebApiExtensions.csproj
+++ b/dvelop-sdk-webapi/WebApiExtensions/WebApiExtensions.csproj
@@ -5,26 +5,18 @@
         <AssemblyName>Dvelop.Sdk.WebApiExtensions</AssemblyName>
         <RootNamespace>Dvelop.Sdk.WebApiExtensions</RootNamespace>
         <LangVersion>latestmajor</LangVersion>
-    
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-  </ItemGroup>
-
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\dvelop-sdk-base\BaseInterfaces\BaseInterfaces.csproj" />
-      <ProjectReference Include="..\..\dvelop-sdk-logging\Logging.Abstractions\Logging.Abstractions.csproj" />
-      <ProjectReference Include="..\..\dvelop-sdk-signing\SigningAlgorithms\SigningAlgorithms.csproj" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+        <ProjectReference Include="..\..\dvelop-sdk-base\BaseInterfaces\BaseInterfaces.csproj" />
+        <ProjectReference Include="..\..\dvelop-sdk-logging\Logging.Abstractions\Logging.Abstractions.csproj" />
+        <ProjectReference Include="..\..\dvelop-sdk-signing\SigningAlgorithms\SigningAlgorithms.csproj" />
     </ItemGroup>
 
 </Project>

--- a/dvelop-sdk-webapi/WebApiExtensions/WebApiExtensions.csproj
+++ b/dvelop-sdk-webapi/WebApiExtensions/WebApiExtensions.csproj
@@ -13,7 +13,6 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
         <ProjectReference Include="..\..\dvelop-sdk-base\BaseInterfaces\BaseInterfaces.csproj" />
         <ProjectReference Include="..\..\dvelop-sdk-logging\Logging.Abstractions\Logging.Abstractions.csproj" />
         <ProjectReference Include="..\..\dvelop-sdk-signing\SigningAlgorithms\SigningAlgorithms.csproj" />


### PR DESCRIPTION
- Removed old dependencies from `Microsoft.AspNetCore`-Namespace (from .NET Core 2.2, deprecated since .NET Core 3.1)
- Updated all other dependencies to the latest version
- Refactored UnitTests in `Dv1HmacSha256RequestSigningExtensionTest`, because `DefaultHttpRequest` is internal now
- Updated `CloudCenterDtos` & `IdentityProviderDtos` to .NET 8