### PR TITLE
Changed LogLevel of IDP Client Creation to Debug

### DIFF
--- a/dvelop-sdk-identityprovider/IdentityProviderClient/IdentityProviderClient.cs
+++ b/dvelop-sdk-identityprovider/IdentityProviderClient/IdentityProviderClient.cs
@@ -71,7 +71,7 @@ namespace Dvelop.Sdk.IdentityProvider.Client
             _allowedImpersonatedApps = options.AllowedImpersonatedApps;
             _allowImpersonatedUsers = options.AllowImpersonatedUsers;
             _logCallback = options.LogCallBack;
-            _logCallback?.Invoke(IdentityProviderClientLogLevel.Info, "IdentityProviderClient initialized");
+            _logCallback?.Invoke(IdentityProviderClientLogLevel.Debug, "IdentityProviderClient initialized");
         }
 
         public static string CookieName => COOKIENAME;


### PR DESCRIPTION
Changed LogLevel of IDP Client Creation to Debug

- The LogLevel of Info leads to too many logLines